### PR TITLE
Update rockblock_send_text.py

### DIFF
--- a/examples/rockblock_send_text.py
+++ b/examples/rockblock_send_text.py
@@ -16,7 +16,7 @@ from adafruit_rockblock import RockBlock
 rb = RockBlock(uart)
 
 # set the text
-rb.out_text = "hello world"
+rb.text_out = "hello world"
 
 # try a satellite Short Burst Data transfer
 print("Talking to satellite...")


### PR DESCRIPTION
The function was not out_text() and the example was not working. Corrected to text_out().