### PR TITLE
Add features: IMEI, RSSI, Versions, Geolocation, Time, Ring Alerts, handle non-responsive modem

### DIFF
--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -42,6 +42,7 @@ Implementation Notes
 
 """
 
+
 import time
 import struct
 
@@ -56,29 +57,44 @@ class RockBlock:
         self._uart = uart
         self._uart.baudrate = baudrate
         self._buf_out = None
-        self.reset()
+        # self.reset()
 
     def _uart_xfer(self, cmd):
         """Send AT command and return response as tuple of lines read."""
-
+        print("sending command: " + cmd)
         self._uart.reset_input_buffer()
         self._uart.write(str.encode("AT" + cmd + "\r"))
 
         resp = []
         line = self._uart.readline()
-        resp.append(line)
-        while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
-            line = self._uart.readline()
+        print("uart line: " + line.decode())
+        if line is None:
+            # print("No response from Modem")
+            return None
+        else:
             resp.append(line)
+            while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
+                line = self._uart.readline()
+                print("uart line: " + line.decode())
+                resp.append(line)
 
-        self._uart.reset_input_buffer()
+            self._uart.reset_input_buffer()
 
-        return tuple(resp)
+            return tuple(resp)
 
     def reset(self):
         """Perform a software reset."""
-        self._uart_xfer("&F0")  # factory defaults
-        self._uart_xfer("&K0")  # flow control off
+        if self._uart_xfer("&F0") is None:  # factory defaults
+            return False
+        else:
+            if self._uart_xfer("&K0") is None:  # flow control off
+                return False
+            else:
+                return True
+
+    def _transfer_buffer(self):
+        """Copy out buffer to in buffer to simulate receiving a message."""
+        self._uart_xfer("+SBDTC")
 
     @property
     def data_out(self):
@@ -199,6 +215,162 @@ class RockBlock:
             return resp[1].strip().decode()
         return None
 
-    def _transfer_buffer(self):
-        """Copy out buffer to in buffer to simulate receiving a message."""
-        self._uart_xfer("+SBDTC")
+    @property
+    def imei(self):
+        """Return modem imei/serial."""
+        resp = self._uart_xfer("+CGSN")
+        if resp[-1].strip().decode() == "OK":
+            return resp[1].strip().decode()
+        return None
+
+    @property
+    def rssi(self):
+        """Return Received Signal Strength Indicator (RSSI), values returned are 0 to 5, where 0 is no signal (0 bars) and 5 is strong signal (5 bars).
+        Important note: signal strength may not be fully accurate, so waiting for high signal strength prior to sending a message isn't always recommended.
+        For details see https://docs.rockblock.rock7.com/docs/checking-the-signal-strength
+        """
+        resp = self._uart_xfer("+CSQ")
+        if resp[-1].strip().decode() == "OK":
+            return resp[1].strip().decode().split(":")[1]
+        return None
+
+    @property
+    def version(self):
+        """Return the modem components' firmware versions.
+        For example: Call Processor Version, Modem DSP Version, DBB Version (ASIC), RFA VersionSRFA2), NVM Version, Hardware Version, BOOT Version
+        """
+        resp = self._uart_xfer("+CGMR")
+        if resp[-1].strip().decode() == "OK":
+            lines = []
+            for x in range(1, len(resp) - 2):
+                line = resp[x]
+                if line != b"\r\n":
+                    lines.append(line.decode().strip())
+            return lines
+        return None
+
+    @property
+    def ring_alert(self):
+        """Retrieve setting for SBD Ring Alerts."""
+        resp = self._uart_xfer("+SBDMTA?")
+        if resp[-1].strip().decode() == "OK":
+            return bool(int(resp[1].strip().decode().split(":")[1]))
+        return None
+
+    @ring_alert.setter
+    def ring_alert(self, value=1):
+        """Enable or disable ring alert feature."""
+        if value in [True, False]:
+            resp = self._uart_xfer("+SBDMTA=" + str(int(value)))
+            if resp[-1].strip().decode() == "OK":
+                return True
+            else:
+                raise RuntimeError("Error setting Ring Alert.")
+        else:
+            raise ValueError(
+                "Use 0 or False to disable Ring Alert or use 0 or True to enable Ring Alert."
+            )
+
+    @property
+    def ring_indication(self):
+        """
+        Query the ring indication status, returning the reason for the most recent assertion of the Ring Indicate signal.
+        The response contains separate indications for telephony and SBD ring indications.
+        The response is in the form:
+        [<tel_ri>,<sbd_ri>]
+            where <tel_ri> indicates the telephony ring indication status:
+                0 No telephony ring alert received.
+                1 Incoming voice call.
+                2 Incoming data call.
+                3 Incoming fax call.
+            and <sbd_ri> indicates the SBD ring indication status:
+                0 No SBD ring alert received.
+                1 SBD ring alert received.
+        """
+        resp = self._uart_xfer("+CRIS")
+        if resp[-1].strip().decode() == "OK":
+            return resp[1].strip().decode().split(":")[1].split(",")
+        return None
+
+    @property
+    def geolocation(self):
+        """
+        Return the geolocation of the modem as measured by the Iridium constellation and the current time based on the Iridium network timestamp.
+        The response is in the form:
+        [<x>,<y>,<z>,<timestamp>]
+        <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system, using dimensions, x, y, and z, to specify location. The coordinate system is aligned such that the z-axis is aligned with the north and south poles, leaving the x-axis and y-axis to lie in the plane containing the equator. The axes are aligned such that at 0 degrees latitude and 0 degrees longitude, both y and z are zero and x is positive (x = +6376, representing the nominal earth radius in kilometres). Each dimension of the geolocation grid code is displayed in decimal form using units of kilometres. Each dimension of the geolocation grid code has a minimum value of –6376, a maximum value of +6376, and a resolution of 4.
+        This geolocation coordinate system is known as ECEF (acronym for earth-centered, earth-fixed), also known as ECR (initialism for earth-centered rotational)
+        The timestamp is assigned by the modem when the geolocation grid code received from the network is stored to the modem's internal memory.
+        The timestamp used by the modem is Iridium system time, which is a running count of 90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        We convert the modem's timestamp and return it as a time_struct representing the current date and time UTC.
+        """
+        resp = self._uart_xfer("-MSGEO")
+        if resp[-1].strip().decode() == "OK":
+            temp = resp[1].strip().decode().split(":")[1].split(",")
+            ticks_since_epoch = int(temp[3], 16)
+            ms_since_epoch = (
+                ticks_since_epoch * 90
+            )  # convert iridium ticks to milliseconds
+
+            # milliseconds to seconds
+            # hack to divide by 1000 and avoid using limited floating point math which throws the calculations off quite a bit, this should be accurate to 1 second or so
+            ms_str = str(ms_since_epoch)
+            substring = ms_str[0 : len(ms_str) - 3]
+            secs_since_epoch = int(substring)
+
+            # iridium epoch
+            iridium_epoch = time.struct_time(((2014), (5), 11, 14, 23, 55, 6, -1, -1))
+            iridium_epoch_unix = time.mktime(iridium_epoch)
+
+            # add timestamp's seconds to the iridium epoch
+            time_now_unix = iridium_epoch_unix + int(secs_since_epoch)
+
+            # convert to time struct
+            time_now = time.localtime(time_now_unix)
+
+            values = [
+                int(temp[0]),
+                int(temp[1]),
+                int(temp[2]),
+                time_now,
+            ]
+            return values
+        return None
+
+    @property
+    def timestamp(self):
+        """
+        Return the current date and time as given by the Iridium network
+        The timestamp used by the modem is Iridium system time, which is a running count of 90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        We convert the modem's timestamp and return it as a time_struct representing the current date and time UTC.
+        If the satellite network is not available then we return None
+        """
+        resp = self._uart_xfer("-MSSTM")
+        if resp[-1].strip().decode() == "OK":
+            temp = resp[1].strip().decode().split(":")[1]
+            print(temp)
+            if temp == " no network service":
+                return None
+            ticks_since_epoch = int(temp, 16)
+            ms_since_epoch = (
+                ticks_since_epoch * 90
+            )  # convert iridium ticks to milliseconds
+
+            # milliseconds to seconds
+            # hack to divide by 1000 and avoid using limited floating point math which throws the calculations off quite a bit, this should be accurate to 1 second or so
+            ms_str = str(ms_since_epoch)
+            substring = ms_str[0 : len(ms_str) - 3]
+            secs_since_epoch = int(substring)
+
+            # iridium epoch
+            iridium_epoch = time.struct_time(((2014), (5), 11, 14, 23, 55, 6, -1, -1))
+            iridium_epoch_unix = time.mktime(iridium_epoch)
+
+            # add timestamp's seconds to the iridium epoch
+            time_now_unix = iridium_epoch_unix + int(secs_since_epoch)
+
+            # convert to time struct
+            time_now = time.localtime(time_now_unix)
+
+            return time_now
+        return None

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -77,11 +77,8 @@ class RockBlock:
 
     def reset(self):
         """Perform a software reset."""
-        if self._uart_xfer("&F0")[0] is None:  # factory defaults
-            return False
-        if self._uart_xfer("&K0")[0] is None:  # flow control off
-            return False
-        return True
+        self._uart_xfer("&F0")  # factory defaults
+        self._uart_xfer("&K0")  # flow control off
 
     def _transfer_buffer(self):
         """Copy out buffer to in buffer to simulate receiving a message."""
@@ -275,8 +272,8 @@ class RockBlock:
         return None
 
     @ring_alert.setter
-    def ring_alert(self, value=1):
-        if value in [True, False]:
+    def ring_alert(self, value):
+        if value in (True, False):
             resp = self._uart_xfer("+SBDMTA=" + str(int(value)))
             if resp[-1].strip().decode() == "OK":
                 return True
@@ -369,17 +366,12 @@ class RockBlock:
 
             # add timestamp's seconds to the iridium epoch
             time_now_unix = iridium_epoch_unix + int(secs_since_epoch)
-
-            # convert to time struct
-            time_now = time.localtime(time_now_unix)
-
-            values = [
+            return (
                 int(temp[0]),
                 int(temp[1]),
                 int(temp[2]),
-                time_now,
-            ]
-            return tuple(values)
+                time.localtime(time_now_unix),
+            )
         return (None,) * 4
 
     @property
@@ -426,9 +418,5 @@ class RockBlock:
 
             # add timestamp's seconds to the iridium epoch
             time_now_unix = iridium_epoch_unix + int(secs_since_epoch)
-
-            # convert to time struct
-            time_now = time.localtime(time_now_unix)
-
-            return time_now
+            return time.localtime(time_now_unix)
         return None

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -228,7 +228,7 @@ class RockBlock:
         return None
 
     @property
-    def version(self):
+    def revision(self):
         """Return the modem components' firmware versions.
         For example: Call Processor Version, Modem DSP Version, DBB Version (ASIC),
         RFA VersionSRFA2), NVM Version, Hardware Version, BOOT Version

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -406,7 +406,6 @@ class RockBlock:
         resp = self._uart_xfer("-MSSTM")
         if resp[-1].strip().decode() == "OK":
             temp = resp[1].strip().decode().split(":")[1]
-            print(temp)
             if temp == " no network service":
                 return None
             ticks_since_epoch = int(temp, 16)

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -66,9 +66,6 @@ class RockBlock:
 
         resp = []
         line = self._uart.readline()
-        if line is None:
-            # No response from Modem
-            return None
         resp.append(line)
         while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
             line = self._uart.readline()

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -222,8 +222,10 @@ class RockBlock:
 
     @property
     def rssi(self):
-        """Return Received Signal Strength Indicator (RSSI), values returned are 0 to 5, where 0 is no signal (0 bars) and 5 is strong signal (5 bars).
-        Important note: signal strength may not be fully accurate, so waiting for high signal strength prior to sending a message isn't always recommended.
+        """Return Received Signal Strength Indicator (RSSI)
+        values returned are 0 to 5, where 0 is no signal (0 bars) and 5 is strong signal (5 bars).
+        Important note: signal strength may not be fully accurate, so
+            waiting for high signal strength prior to sending a message isn't always recommended.
         For details see https://docs.rockblock.rock7.com/docs/checking-the-signal-strength
         """
         resp = self._uart_xfer("+CSQ")
@@ -234,7 +236,8 @@ class RockBlock:
     @property
     def version(self):
         """Return the modem components' firmware versions.
-        For example: Call Processor Version, Modem DSP Version, DBB Version (ASIC), RFA VersionSRFA2), NVM Version, Hardware Version, BOOT Version
+        For example: Call Processor Version, Modem DSP Version, DBB Version (ASIC),
+        RFA VersionSRFA2), NVM Version, Hardware Version, BOOT Version
         """
         resp = self._uart_xfer("+CGMR")
         if resp[-1].strip().decode() == "OK":
@@ -271,7 +274,9 @@ class RockBlock:
     @property
     def ring_indication(self):
         """
-        Query the ring indication status, returning the reason for the most recent assertion of the Ring Indicate signal.
+        Query the ring indication status, returning the reason for the most recent assertion
+        of the Ring Indicate signal.
+
         The response contains separate indications for telephony and SBD ring indications.
         The response is in the form:
         [<tel_ri>,<sbd_ri>]
@@ -292,14 +297,27 @@ class RockBlock:
     @property
     def geolocation(self):
         """
-        Return the geolocation of the modem as measured by the Iridium constellation and the current time based on the Iridium network timestamp.
+        Return the geolocation of the modem as measured by the Iridium constellation
+        and the current time based on the Iridium network timestamp.
         The response is in the form:
         [<x>,<y>,<z>,<timestamp>]
-        <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system, using dimensions, x, y, and z, to specify location. The coordinate system is aligned such that the z-axis is aligned with the north and south poles, leaving the x-axis and y-axis to lie in the plane containing the equator. The axes are aligned such that at 0 degrees latitude and 0 degrees longitude, both y and z are zero and x is positive (x = +6376, representing the nominal earth radius in kilometres). Each dimension of the geolocation grid code is displayed in decimal form using units of kilometres. Each dimension of the geolocation grid code has a minimum value of –6376, a maximum value of +6376, and a resolution of 4.
-        This geolocation coordinate system is known as ECEF (acronym for earth-centered, earth-fixed), also known as ECR (initialism for earth-centered rotational)
-        The timestamp is assigned by the modem when the geolocation grid code received from the network is stored to the modem's internal memory.
-        The timestamp used by the modem is Iridium system time, which is a running count of 90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
-        We convert the modem's timestamp and return it as a time_struct representing the current date and time UTC.
+        <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system,
+            using dimensions, x, y, and z, to specify location. The coordinate system is aligned such
+            that the z-axis is aligned with the north and south poles, leaving the x-axis and y-axis
+            to lie in the plane containing the equator. The axes are aligned such that at 0 degrees
+            latitude and 0 degrees longitude, both y and z are zero and x is positive (x = +6376,
+            representing the nominal earth radius in kilometres). Each dimension of the
+            geolocation grid code is displayed in decimal form using units of kilometres.
+            Each dimension of the geolocation grid code has a minimum value of –6376,
+            a maximum value of +6376, and a resolution of 4.
+        This geolocation coordinate system is known as ECEF (acronym earth-centered, earth-fixed),
+            also known as ECR (initialism for earth-centered rotational)
+
+        The timestamp is assigned by the modem when the geolocation grid code received from
+            the network is stored to the modem's internal memory.
+        The timestamp used by the modem is Iridium system time, which is a running count of
+            90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        We convert the modem's timestamp and return it as a time_struct.
         """
         resp = self._uart_xfer("-MSGEO")
         if resp[-1].strip().decode() == "OK":
@@ -310,7 +328,8 @@ class RockBlock:
             )  # convert iridium ticks to milliseconds
 
             # milliseconds to seconds
-            # hack to divide by 1000 and avoid using limited floating point math which throws the calculations off quite a bit, this should be accurate to 1 second or so
+            # hack to divide by 1000 and avoid using limited floating point math which throws the
+            #    calculations off quite a bit, this should be accurate to 1 second or so
             ms_str = str(ms_since_epoch)
             substring = ms_str[0 : len(ms_str) - 3]
             secs_since_epoch = int(substring)
@@ -338,9 +357,11 @@ class RockBlock:
     def timestamp(self):
         """
         Return the current date and time as given by the Iridium network
-        The timestamp used by the modem is Iridium system time, which is a running count of 90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
-        We convert the modem's timestamp and return it as a time_struct representing the current date and time UTC.
-        If the satellite network is not available then we return None
+        The timestamp is assigned by the modem when the geolocation grid code received from
+            the network is stored to the modem's internal memory.
+        The timestamp used by the modem is Iridium system time, which is a running count of
+            90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        We convert the modem's timestamp and return it as a time_struct.
         """
         resp = self._uart_xfer("-MSSTM")
         if resp[-1].strip().decode() == "OK":
@@ -353,8 +374,9 @@ class RockBlock:
                 ticks_since_epoch * 90
             )  # convert iridium ticks to milliseconds
 
-            # milliseconds to seconds
-            # hack to divide by 1000 and avoid using limited floating point math which throws the calculations off quite a bit, this should be accurate to 1 second or so
+            # milliseconds to seconds\
+            # hack to divide by 1000 and avoid using limited floating point math which throws the
+            #    calculations off quite a bit, this should be accurate to 1 second or so
             ms_str = str(ms_since_epoch)
             substring = ms_str[0 : len(ms_str) - 3]
             secs_since_epoch = int(substring)

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -57,7 +57,7 @@ class RockBlock:
         self._uart = uart
         self._uart.baudrate = baudrate
         self._buf_out = None
-        # self.reset()
+        self.reset()
 
     def _uart_xfer(self, cmd):
         """Send AT command and return response as tuple of lines read."""

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -61,13 +61,11 @@ class RockBlock:
 
     def _uart_xfer(self, cmd):
         """Send AT command and return response as tuple of lines read."""
-        print("sending command: " + cmd)
         self._uart.reset_input_buffer()
         self._uart.write(str.encode("AT" + cmd + "\r"))
 
         resp = []
         line = self._uart.readline()
-        print("uart line: " + line.decode())
         if line is None:
             # print("No response from Modem")
             return None
@@ -75,7 +73,6 @@ class RockBlock:
             resp.append(line)
             while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
                 line = self._uart.readline()
-                print("uart line: " + line.decode())
                 resp.append(line)
 
             self._uart.reset_input_buffer()

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -67,27 +67,24 @@ class RockBlock:
         resp = []
         line = self._uart.readline()
         if line is None:
-            # print("No response from Modem")
+            # No response from Modem
             return None
-        else:
+        resp.append(line)
+        while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
+            line = self._uart.readline()
             resp.append(line)
-            while not any(EOM in line for EOM in (b"OK\r\n", b"ERROR\r\n")):
-                line = self._uart.readline()
-                resp.append(line)
 
-            self._uart.reset_input_buffer()
+        self._uart.reset_input_buffer()
 
-            return tuple(resp)
+        return tuple(resp)
 
     def reset(self):
         """Perform a software reset."""
         if self._uart_xfer("&F0") is None:  # factory defaults
             return False
-        else:
-            if self._uart_xfer("&K0") is None:  # flow control off
-                return False
-            else:
-                return True
+        if self._uart_xfer("&K0") is None:  # flow control off
+            return False
+        return True
 
     def _transfer_buffer(self):
         """Copy out buffer to in buffer to simulate receiving a message."""
@@ -264,8 +261,7 @@ class RockBlock:
             resp = self._uart_xfer("+SBDMTA=" + str(int(value)))
             if resp[-1].strip().decode() == "OK":
                 return True
-            else:
-                raise RuntimeError("Error setting Ring Alert.")
+            raise RuntimeError("Error setting Ring Alert.")
         else:
             raise ValueError(
                 "Use 0 or False to disable Ring Alert or use 0 or True to enable Ring Alert."
@@ -302,14 +298,14 @@ class RockBlock:
         The response is in the form:
         [<x>,<y>,<z>,<timestamp>]
         <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system,
-            using dimensions, x, y, and z, to specify location. The coordinate system is aligned such
-            that the z-axis is aligned with the north and south poles, leaving the x-axis and y-axis
-            to lie in the plane containing the equator. The axes are aligned such that at 0 degrees
-            latitude and 0 degrees longitude, both y and z are zero and x is positive (x = +6376,
-            representing the nominal earth radius in kilometres). Each dimension of the
-            geolocation grid code is displayed in decimal form using units of kilometres.
-            Each dimension of the geolocation grid code has a minimum value of –6376,
-            a maximum value of +6376, and a resolution of 4.
+            using dimensions, x, y, and z, to specify location. The coordinate system is aligned
+            such that the z-axis is aligned with the north and south poles, leaving the x-axis
+            and y-axis to lie in the plane containing the equator. The axes are aligned such that
+            at 0 degrees latitude and 0 degrees longitude, both y and z are zero and
+            x is positive (x = +6376, representing the nominal earth radius in kilometres).
+            Each dimension of the geolocation grid code is displayed in decimal form using
+            units of kilometres. Each dimension of the geolocation grid code has a minimum value
+            of –6376, a maximum value of +6376, and a resolution of 4.
         This geolocation coordinate system is known as ECEF (acronym earth-centered, earth-fixed),
             also known as ECR (initialism for earth-centered rotational)
 

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -281,7 +281,7 @@ class RockBlock:
         1 Incoming voice call.
         2 Incoming data call.
         3 Incoming fax call.
-            
+
         <sbd_ri> indicates the SBD ring indication status:
         0 No SBD ring alert received.
         1 SBD ring alert received.

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -207,7 +207,7 @@ class RockBlock:
         return None
 
     @property
-    def imei(self):
+    def serial_number(self):
         """Return modem imei/serial."""
         resp = self._uart_xfer("+CGSN")
         if resp[-1].strip().decode() == "OK":

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -262,10 +262,9 @@ class RockBlock:
             if resp[-1].strip().decode() == "OK":
                 return True
             raise RuntimeError("Error setting Ring Alert.")
-        else:
-            raise ValueError(
-                "Use 0 or False to disable Ring Alert or use 0 or True to enable Ring Alert."
-            )
+        raise ValueError(
+            "Use 0 or False to disable Ring Alert or use 0 or True to enable Ring Alert."
+        )
 
     @property
     def ring_indication(self):

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -222,7 +222,7 @@ class RockBlock:
         """Return Received Signal Strength Indicator (RSSI)
         values returned are 0 to 5, where 0 is no signal (0 bars) and 5 is strong signal (5 bars).
         Important note: signal strength may not be fully accurate, so
-            waiting for high signal strength prior to sending a message isn't always recommended.
+        waiting for high signal strength prior to sending a message isn't always recommended.
         For details see https://docs.rockblock.rock7.com/docs/checking-the-signal-strength
         """
         resp = self._uart_xfer("+CSQ")
@@ -275,14 +275,16 @@ class RockBlock:
         The response contains separate indications for telephony and SBD ring indications.
         The response is in the form:
         [<tel_ri>,<sbd_ri>]
-            where <tel_ri> indicates the telephony ring indication status:
-                0 No telephony ring alert received.
-                1 Incoming voice call.
-                2 Incoming data call.
-                3 Incoming fax call.
-            and <sbd_ri> indicates the SBD ring indication status:
-                0 No SBD ring alert received.
-                1 SBD ring alert received.
+
+        <tel_ri> indicates the telephony ring indication status:
+        0 No telephony ring alert received.
+        1 Incoming voice call.
+        2 Incoming data call.
+        3 Incoming fax call.
+            
+        <sbd_ri> indicates the SBD ring indication status:
+        0 No SBD ring alert received.
+        1 SBD ring alert received.
         """
         resp = self._uart_xfer("+CRIS")
         if resp[-1].strip().decode() == "OK":
@@ -296,22 +298,25 @@ class RockBlock:
         and the current time based on the Iridium network timestamp.
         The response is in the form:
         [<x>,<y>,<z>,<timestamp>]
-        <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system,
-            using dimensions, x, y, and z, to specify location. The coordinate system is aligned
-            such that the z-axis is aligned with the north and south poles, leaving the x-axis
-            and y-axis to lie in the plane containing the equator. The axes are aligned such that
-            at 0 degrees latitude and 0 degrees longitude, both y and z are zero and
-            x is positive (x = +6376, representing the nominal earth radius in kilometres).
-            Each dimension of the geolocation grid code is displayed in decimal form using
-            units of kilometres. Each dimension of the geolocation grid code has a minimum value
-            of –6376, a maximum value of +6376, and a resolution of 4.
-        This geolocation coordinate system is known as ECEF (acronym earth-centered, earth-fixed),
-            also known as ECR (initialism for earth-centered rotational)
 
+        <x>,<y>,<z> is a geolocation grid code from an earth centered Cartesian coordinate system,
+        using dimensions, x, y, and z, to specify location. The coordinate system is aligned
+        such that the z-axis is aligned with the north and south poles, leaving the x-axis
+        and y-axis to lie in the plane containing the equator. The axes are aligned such that
+        at 0 degrees latitude and 0 degrees longitude, both y and z are zero and
+        x is positive (x = +6376, representing the nominal earth radius in kilometres).
+        Each dimension of the geolocation grid code is displayed in decimal form using
+        units of kilometres. Each dimension of the geolocation grid code has a minimum value
+        of –6376, a maximum value of +6376, and a resolution of 4.
+        This geolocation coordinate system is known as ECEF (acronym earth-centered, earth-fixed),
+        also known as ECR (initialism for earth-centered rotational)
+
+        <timestamp> is a time_struct
         The timestamp is assigned by the modem when the geolocation grid code received from
-            the network is stored to the modem's internal memory.
+        the network is stored to the modem's internal memory.
         The timestamp used by the modem is Iridium system time, which is a running count of
-            90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        The timestamp returned by the modem is a 32-bit integer displayed in hexadecimal form.
         We convert the modem's timestamp and return it as a time_struct.
         """
         resp = self._uart_xfer("-MSGEO")
@@ -353,9 +358,9 @@ class RockBlock:
         """
         Return the current date and time as given by the Iridium network
         The timestamp is assigned by the modem when the geolocation grid code received from
-            the network is stored to the modem's internal memory.
+        the network is stored to the modem's internal memory.
         The timestamp used by the modem is Iridium system time, which is a running count of
-            90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
+        90 millisecond intervals, since Sunday May 11, 2014, at 14:23:55 UTC.
         We convert the modem's timestamp and return it as a time_struct.
         """
         resp = self._uart_xfer("-MSSTM")
@@ -371,7 +376,7 @@ class RockBlock:
 
             # milliseconds to seconds\
             # hack to divide by 1000 and avoid using limited floating point math which throws the
-            #    calculations off quite a bit, this should be accurate to 1 second or so
+            # calculations off quite a bit, this should be accurate to 1 second or so
             ms_str = str(ms_since_epoch)
             substring = ms_str[0 : len(ms_str) - 3]
             secs_since_epoch = int(substring)


### PR DESCRIPTION
I added functionality to return the modem's IMEI (serial number), RSSI (signal strength), firmware versions, it's geolocation per the Iridium network, the date/time per Iridium network, the ability to enable/disable ring alerts, and lastly the ability to check for ring alerts.

I made changes to handle a non-responsive modem (in case it is powered off) by modifying _uart_xfer to return None if there is no response from the modem. This will require additional changes to several other functions. I'm not sure this was the best way to do it, so I have not updated all the other functions yet. I would like to get some feedback first. If you have a better suggestion, or think this is ok, please let me know and I'll update accordingly. 

Thank you,
Jeremy