### PR TITLE
add accumulated energy monitor feature (AT+GEMON)

### DIFF
--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -441,7 +441,7 @@ class RockBlock:
         Note: Call Processor Version: TA12003 is known to not support the AT+GEMON energy
         monitor command. It is however known to work on TA19002 (newer) and TA12003 (older).
         You may use the revision function to determine which version you have. Function will
-        return None if modem cannot retrieve the accumuulated energy usage estimate.
+        return None if modem cannot retrieve the accumulated energy usage estimate.
 
         Returns
         int

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -423,7 +423,7 @@ class RockBlock:
 
     @property
     def energy_monitor(self):
-        """Report the current accumulated energy usage estimate in microamp hours.
+        """The current accumulated energy usage estimate in microamp hours.
 
         Returns an estimate of the charge taken from the +5V supply to the modem,
         in microamp hours (uAh). This is represented internally as a 26-bit unsigned number,

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -438,7 +438,7 @@ class RockBlock:
         The setter will preset the energy monitor accumulator to value n (typically, <n> would
         be specified as 0, to clear the accumulator).
 
-        Note: Call Processor Version: TA12003 is known to not support the AT+GEMON energy
+        Note: Call Processor/BOOT Version: TA16005 is known to not support the AT+GEMON energy
         monitor command. It is however known to work on TA19002 (newer) and TA12003 (older).
         You may use the revision function to determine which version you have. Function will
         return None if modem cannot retrieve the accumulated energy usage estimate.


### PR DESCRIPTION
I've added code to query the modem's accumulated energy monitor, +GEMON which returns an estimate of the microamp hours the modem has consumed. I think it would be very useful for anyone running off batteries/solar/etc. 

However the software revision I have on several modems does not support this. I do have an older modem that does support it, and RockBlock support shows it working on a newer revision than what I have. I've tested on both revisions.

Documented in code with "Note: Call Processor Version: TA16005 is known to not support the AT+GEMON energy monitor command. It is however known to work on TA19002 (newer) and TA12003 (older). You may use the revision function to determine which version you have. Function will return None if modem cannot retrieve the accumulated energy usage estimate."

This code returns None if the modem returns ERROR when issuing the +GEMON command. It raises a RuntimeError if the setter is unable to preset the accumulator value.