### PR TITLE
change <MO status> parameter check from 8 to 5, 5+ == send failure not 8+

### DIFF
--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -181,7 +181,7 @@ class RockBlock:
         if resp[-1].strip().decode() == "OK":
             status = resp[-3].strip().decode().split(":")[1]
             status = [int(s) for s in status.split(",")]
-            if status[0] <= 4:
+            if status[0] <= 5:
                 # outgoing message sent successfully
                 self.data_out = None
         return tuple(status)

--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -181,7 +181,7 @@ class RockBlock:
         if resp[-1].strip().decode() == "OK":
             status = resp[-3].strip().decode().split(":")[1]
             status = [int(s) for s in status.split(",")]
-            if status[0] <= 8:
+            if status[0] <= 4:
                 # outgoing message sent successfully
                 self.data_out = None
         return tuple(status)


### PR DESCRIPTION
Change <MO status> parameter check from 8 to 5. 
5+ is a send failure not 8+

This is described on page 88 of IRDM_ISU_ATCommandReferenceMAN0009_Rev2.0_ATCOMM_Oct2012.pdf 
> \<MO status>:
MO session status provides an indication of the disposition of the mobile originated transaction. The field can take on the following values:
Gateway-reported values:
-> 0 MO message, if any, transferred successfully.
-> 1 MO message, if any, transferred successfully, but the MT message in the queue was too big to be transferred.
-> 2 MO message, if any, transferred successfully, but the requested Location Update was not accepted.
-> 3..4 Reserved, but indicate MO session success if used.
-> 5..8 Reserved, but indicate MO session failure if used.
...