### PR TITLE
Update adafruit_rockblock.py

### DIFF
--- a/adafruit_rockblock.py
+++ b/adafruit_rockblock.py
@@ -213,7 +213,7 @@ class RockBlock:
         """
         resp = self._uart_xfer("+CSQ")
         if resp[-1].strip().decode() == "OK":
-            return int(resp[1].strip().decode().split(":")[1])
+            return int(resp[-3].strip().decode().split(":")[1])
         return None
 
     @property


### PR DESCRIPTION
Currently getting `IndexError: list index out of range`

Due to response being like `(b'AT+CSQ\r', b'', b'', b'\r\n', b'+CSQ:0\r\n', b'\r\n', b'OK\r\n')`

Setting the index to -3 solves this issue.